### PR TITLE
extract LWJGL 2 natives for legacy Minecraft versions

### DIFF
--- a/internal/cli/cmd/instance.go
+++ b/internal/cli/cmd/instance.go
@@ -8,6 +8,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/telecter/cmd-launcher/internal/cli/output"
+	"github.com/telecter/cmd-launcher/internal/meta"
 	"github.com/telecter/cmd-launcher/pkg/launcher"
 )
 
@@ -20,18 +21,18 @@ type CreateCmd struct {
 }
 
 func (c *CreateCmd) Run(ctx *kong.Context) error {
-	var loader launcher.Loader
+	var loader meta.Loader
 	switch c.Loader {
 	case "fabric":
-		loader = launcher.LoaderFabric
+		loader = meta.LoaderFabric
 	case "quilt":
-		loader = launcher.LoaderQuilt
+		loader = meta.LoaderQuilt
 	case "vanilla":
-		loader = launcher.LoaderVanilla
+		loader = meta.LoaderVanilla
 	case "neoforge":
-		loader = launcher.LoaderNeoForge
+		loader = meta.LoaderNeoForge
 	case "forge":
-		loader = launcher.LoaderForge
+		loader = meta.LoaderForge
 	}
 	inst, err := launcher.CreateInstance(launcher.InstanceOptions{
 		GameVersion:   c.Version,

--- a/internal/meta/all.go
+++ b/internal/meta/all.go
@@ -1,0 +1,63 @@
+package meta
+
+import (
+	"fmt"
+)
+
+// Loader represents a game mod loader.
+type Loader string
+
+const (
+	LoaderVanilla  Loader = "vanilla"
+	LoaderFabric   Loader = "fabric"
+	LoaderQuilt    Loader = "quilt"
+	LoaderNeoForge Loader = "neoforge"
+	LoaderForge    Loader = "forge"
+)
+
+// FetchAllVersionMeta returns a VersionMeta containing both information for the base game, and specified mod loader.
+func FetchAllVersionMeta(loader Loader, gameVersion string, loaderVersion string) (VersionMeta, error) {
+	var loaderMeta VersionMeta
+	var err error
+
+	version, err := FetchVersionMeta(gameVersion)
+	if err != nil {
+		return VersionMeta{}, fmt.Errorf("retrieve version metadata: %w", err)
+	}
+
+	switch loader {
+	case LoaderFabric, LoaderQuilt:
+		api := Fabric
+		if loader == LoaderQuilt {
+			api = Quilt
+		}
+		loaderMeta, err = api.FetchMeta(version.ID, loaderVersion)
+		if err != nil {
+			return VersionMeta{}, fmt.Errorf("retrieve Fabric/Quilt metadata: %w", err)
+		}
+	case LoaderNeoForge:
+		if loaderVersion == "latest" {
+			loaderVersion, err = FetchNeoforgeVersion(version.ID)
+			if err != nil {
+				return VersionMeta{}, fmt.Errorf("retrieve NeoForge version: %w", err)
+			}
+		}
+		loaderMeta, _, err = Neoforge.FetchMeta(loaderVersion)
+		if err != nil {
+			return VersionMeta{}, fmt.Errorf("retrieve NeoForge metadata: %w", err)
+		}
+	case LoaderForge:
+		if loaderVersion == "latest" {
+			loaderVersion, err = FetchForgeVersion(version.ID)
+			if err != nil {
+				return VersionMeta{}, fmt.Errorf("retrieve Forge version: %w", err)
+			}
+		}
+		loaderMeta, _, err = Forge.FetchMeta(loaderVersion)
+		if err != nil {
+			return VersionMeta{}, fmt.Errorf("retrieve Forge metadata: %w", err)
+		}
+	}
+
+	return MergeVersionMeta(version, loaderMeta), nil
+}

--- a/pkg/launcher/instance.go
+++ b/pkg/launcher/instance.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/pelletier/go-toml/v2"
+	"github.com/telecter/cmd-launcher/internal/meta"
 	env "github.com/telecter/cmd-launcher/pkg"
 )
 
@@ -15,7 +16,7 @@ import (
 type Instance struct {
 	Name          string         `toml:"-" json:"-"`
 	GameVersion   string         `toml:"game_version" json:"game_version"`
-	Loader        Loader         `toml:"mod_loader" json:"mod_loader"`
+	Loader        meta.Loader    `toml:"mod_loader" json:"mod_loader"`
 	LoaderVersion string         `toml:"mod_loader_version,omitempty" json:"mod_loader_version,omitempty"`
 	Config        InstanceConfig `toml:"config" json:"config"`
 }
@@ -31,6 +32,11 @@ func (inst Instance) WriteConfig() error {
 // Dir returns the instance's directory
 func (inst Instance) Dir() string {
 	return filepath.Join(env.InstancesDir, inst.Name)
+}
+
+// NativesDir returns the path to the instance's natives extraction directory.
+func (inst Instance) NativesDir() string {
+	return filepath.Join(inst.Dir(), "natives")
 }
 
 // Rename renames instance to the specified new name
@@ -59,7 +65,7 @@ type InstanceConfig struct {
 type InstanceOptions struct {
 	Name          string
 	GameVersion   string
-	Loader        Loader
+	Loader        meta.Loader
 	LoaderVersion string
 
 	Config InstanceConfig
@@ -75,7 +81,7 @@ func CreateInstance(options InstanceOptions) (Instance, error) {
 		return Instance{}, fmt.Errorf("instance already exists")
 	}
 
-	version, err := fetchVersion(options.Loader, options.GameVersion, options.LoaderVersion)
+	version, err := meta.FetchAllVersionMeta(options.Loader, options.GameVersion, options.LoaderVersion)
 	if err != nil {
 		return Instance{}, err
 	}

--- a/pkg/launcher/launcher_test.go
+++ b/pkg/launcher/launcher_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/telecter/cmd-launcher/internal/meta"
 	env "github.com/telecter/cmd-launcher/pkg"
 	"github.com/telecter/cmd-launcher/pkg/auth"
 )
@@ -23,7 +24,7 @@ func TestCreateInstance(t *testing.T) {
 			name: "Vanilla",
 			options: InstanceOptions{
 				GameVersion: "release",
-				Loader:      LoaderVanilla,
+				Loader:      meta.LoaderVanilla,
 			},
 			wantError: false,
 		},
@@ -31,7 +32,7 @@ func TestCreateInstance(t *testing.T) {
 			name: "Vanilla Invalid Version",
 			options: InstanceOptions{
 				GameVersion: "not valid",
-				Loader:      LoaderVanilla,
+				Loader:      meta.LoaderVanilla,
 			},
 			wantError: true,
 		},
@@ -39,7 +40,7 @@ func TestCreateInstance(t *testing.T) {
 			name: "Fabric",
 			options: InstanceOptions{
 				GameVersion:   "release",
-				Loader:        LoaderFabric,
+				Loader:        meta.LoaderFabric,
 				LoaderVersion: "latest",
 			},
 			wantError: false,
@@ -48,7 +49,7 @@ func TestCreateInstance(t *testing.T) {
 			name: "Fabric Versioned",
 			options: InstanceOptions{
 				GameVersion:   "release",
-				Loader:        LoaderFabric,
+				Loader:        meta.LoaderFabric,
 				LoaderVersion: "0.16.14",
 			},
 			wantError: false,
@@ -57,7 +58,7 @@ func TestCreateInstance(t *testing.T) {
 			name: "Fabric Invalid Version",
 			options: InstanceOptions{
 				GameVersion:   "release",
-				Loader:        LoaderFabric,
+				Loader:        meta.LoaderFabric,
 				LoaderVersion: "not valid",
 			},
 			wantError: true,
@@ -66,7 +67,7 @@ func TestCreateInstance(t *testing.T) {
 			name: "Quilt",
 			options: InstanceOptions{
 				GameVersion:   "release",
-				Loader:        LoaderQuilt,
+				Loader:        meta.LoaderQuilt,
 				LoaderVersion: "latest",
 			},
 			wantError: false,
@@ -75,7 +76,7 @@ func TestCreateInstance(t *testing.T) {
 			name: "Quilt Versioned",
 			options: InstanceOptions{
 				GameVersion:   "release",
-				Loader:        LoaderQuilt,
+				Loader:        meta.LoaderQuilt,
 				LoaderVersion: "0.29.0-beta.7",
 			},
 			wantError: false,
@@ -84,7 +85,7 @@ func TestCreateInstance(t *testing.T) {
 			name: "Quilt Invalid Version",
 			options: InstanceOptions{
 				GameVersion:   "release",
-				Loader:        LoaderQuilt,
+				Loader:        meta.LoaderQuilt,
 				LoaderVersion: "not valid",
 			},
 			wantError: true,
@@ -93,7 +94,7 @@ func TestCreateInstance(t *testing.T) {
 			name: "Forge",
 			options: InstanceOptions{
 				GameVersion:   "release",
-				Loader:        LoaderForge,
+				Loader:        meta.LoaderForge,
 				LoaderVersion: "latest",
 			},
 			wantError: false,
@@ -102,7 +103,7 @@ func TestCreateInstance(t *testing.T) {
 			name: "Forge Versioned",
 			options: InstanceOptions{
 				GameVersion:   "1.21.5",
-				Loader:        LoaderForge,
+				Loader:        meta.LoaderForge,
 				LoaderVersion: "1.21.5-55.0.22",
 			},
 			wantError: false,
@@ -111,7 +112,7 @@ func TestCreateInstance(t *testing.T) {
 			name: "Forge Invalid Version",
 			options: InstanceOptions{
 				GameVersion:   "release",
-				Loader:        LoaderForge,
+				Loader:        meta.LoaderForge,
 				LoaderVersion: "not valid",
 			},
 			wantError: true,
@@ -120,7 +121,7 @@ func TestCreateInstance(t *testing.T) {
 			name: "NeoForge",
 			options: InstanceOptions{
 				GameVersion:   "release",
-				Loader:        LoaderNeoForge,
+				Loader:        meta.LoaderNeoForge,
 				LoaderVersion: "latest",
 			},
 			wantError: false,
@@ -129,7 +130,7 @@ func TestCreateInstance(t *testing.T) {
 			name: "NeoForge Versioned",
 			options: InstanceOptions{
 				GameVersion:   "release",
-				Loader:        LoaderNeoForge,
+				Loader:        meta.LoaderNeoForge,
 				LoaderVersion: "21.5.75",
 			},
 			wantError: false,
@@ -138,7 +139,7 @@ func TestCreateInstance(t *testing.T) {
 			name: "NeoForge Invalid Version",
 			options: InstanceOptions{
 				GameVersion:   "release",
-				Loader:        LoaderNeoForge,
+				Loader:        meta.LoaderNeoForge,
 				LoaderVersion: "not valid",
 			},
 			wantError: true,
@@ -168,7 +169,7 @@ func TestFetchAllInstances(t *testing.T) {
 	_, err := CreateInstance(InstanceOptions{
 		Name:        uuid.NewString(),
 		GameVersion: "release",
-		Loader:      LoaderVanilla,
+		Loader:      meta.LoaderVanilla,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error creating instance for test: %s", err)
@@ -187,7 +188,7 @@ func TestRemoveInstance(t *testing.T) {
 	inst, err := CreateInstance(InstanceOptions{
 		Name:        uuid.NewString(),
 		GameVersion: "release",
-		Loader:      LoaderVanilla,
+		Loader:      meta.LoaderVanilla,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error creating instance for test: %s", err)
@@ -205,7 +206,7 @@ func TestRenameInstance(t *testing.T) {
 	inst, err := CreateInstance(InstanceOptions{
 		Name:        uuid.NewString(),
 		GameVersion: "release",
-		Loader:      LoaderVanilla,
+		Loader:      meta.LoaderVanilla,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error creating instance for test: %s", err)
@@ -244,7 +245,7 @@ func TestPrepare(t *testing.T) {
 			name: "Vanilla",
 			options: InstanceOptions{
 				GameVersion: "release",
-				Loader:      LoaderVanilla,
+				Loader:      meta.LoaderVanilla,
 				Config: InstanceConfig{
 					Java: "java",
 				},
@@ -254,14 +255,14 @@ func TestPrepare(t *testing.T) {
 			name: "Vanilla with Mojang JVM",
 			options: InstanceOptions{
 				GameVersion: "release",
-				Loader:      LoaderVanilla,
+				Loader:      meta.LoaderVanilla,
 			},
 		},
 		{
 			name: "Fabric",
 			options: InstanceOptions{
 				GameVersion:   "release",
-				Loader:        LoaderFabric,
+				Loader:        meta.LoaderFabric,
 				LoaderVersion: "latest",
 				Config: InstanceConfig{
 					Java: "java",
@@ -272,7 +273,7 @@ func TestPrepare(t *testing.T) {
 			name: "Quilt",
 			options: InstanceOptions{
 				GameVersion:   "release",
-				Loader:        LoaderQuilt,
+				Loader:        meta.LoaderQuilt,
 				LoaderVersion: "latest",
 				Config: InstanceConfig{
 					Java: "java",
@@ -283,7 +284,7 @@ func TestPrepare(t *testing.T) {
 			name: "Forge",
 			options: InstanceOptions{
 				GameVersion:   "release",
-				Loader:        LoaderForge,
+				Loader:        meta.LoaderForge,
 				LoaderVersion: "latest",
 				Config: InstanceConfig{
 					Java: "java",
@@ -294,7 +295,7 @@ func TestPrepare(t *testing.T) {
 			name: "NeoForge",
 			options: InstanceOptions{
 				GameVersion:   "release",
-				Loader:        LoaderNeoForge,
+				Loader:        meta.LoaderNeoForge,
 				LoaderVersion: "latest",
 				Config: InstanceConfig{
 					Java: "java",

--- a/pkg/launcher/library.go
+++ b/pkg/launcher/library.go
@@ -13,24 +13,19 @@ import (
 // It also runs patchLibrary on each library.
 func filterLibraries(libraries []meta.Library) (installed []meta.Library, required []meta.Library) {
 	for _, library := range libraries {
-		all := []meta.Library{library}
-		all = append(all, library.Natives...)
-
 		if !library.ShouldInstall {
 			continue
 		}
-
-		for _, library := range all {
-			if library.Artifact.URL == "" {
-				installed = append(installed, library)
-				continue
-			}
-			library = patchLibrary(library)
-			if library.Artifact.IsDownloaded() {
-				installed = append(installed, library)
-			} else {
-				required = append(required, library)
-			}
+		if library.Artifact.URL == "" {
+			library.ShouldInstall = false
+			required = append(required, library)
+			continue
+		}
+		library = patchLibrary(library)
+		if library.Artifact.IsDownloaded() {
+			installed = append(installed, library)
+		} else {
+			required = append(required, library)
 		}
 	}
 	return installed, required

--- a/pkg/launcher/natives.go
+++ b/pkg/launcher/natives.go
@@ -1,0 +1,104 @@
+package launcher
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/telecter/cmd-launcher/internal/meta"
+)
+
+// nativesDir returns the path to the natives extraction directory for an instance.
+func nativesDir(instDir string) string {
+	return filepath.Join(instDir, "natives")
+}
+
+// isLegacyNativesJar reports whether a library artifact path is a LWJGL2-style
+// natives JAR that must be extracted manually (pre-1.14 / LWJGL 2).
+func isLegacyNativesJar(artifactPath string) bool {
+	base := filepath.Base(artifactPath)
+	if !strings.Contains(base, "natives-") {
+		return false
+	}
+
+	return strings.Contains(artifactPath, "lwjgl-platform") ||
+		strings.Contains(artifactPath, "jinput-platform") ||
+		strings.Contains(artifactPath, "org/lwjgl/lwjgl/")
+}
+
+// extractNatives extracts all native DLLs/SOs from legacy LWJGL 2 natives JARs
+// into <instDir>/natives/.
+func extractNatives(instDir string, libraries []meta.Library) error {
+	dest := nativesDir(instDir)
+
+	for _, lib := range libraries {
+		path := lib.Artifact.RuntimePath()
+		if !isLegacyNativesJar(path) {
+			continue
+		}
+
+		if err := extractJar(path, dest); err != nil {
+			return fmt.Errorf("extract natives from %s: %w", filepath.Base(path), err)
+		}
+	}
+
+	return nil
+}
+
+// extractJar extracts the contents of a ZIP/JAR at src into the directory dest,
+// skipping files that already exist and META-INF entries.
+func extractJar(src, dest string) error {
+	r, err := zip.OpenReader(src)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	if err := os.MkdirAll(dest, 0755); err != nil {
+		return err
+	}
+
+	for _, f := range r.File {
+		// Skip directories and metadata.
+		if f.FileInfo().IsDir() {
+			continue
+		}
+		if strings.HasPrefix(f.Name, "META-INF/") {
+			continue
+		}
+
+		outPath := filepath.Join(dest, filepath.Base(f.Name))
+
+		// Skip if already extracted.
+		if _, err := os.Stat(outPath); err == nil {
+			continue
+		}
+
+		if err := extractFile(f, outPath); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// extractFile writes a single zip.File entry to outPath.
+func extractFile(f *zip.File, outPath string) error {
+	rc, err := f.Open()
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+
+	out, err := os.OpenFile(outPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, f.Mode())
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, rc)
+	return err
+}


### PR DESCRIPTION
Now supports pre 1.13 versions

Closes https://github.com/telecter/cmd-launcher/issues/3